### PR TITLE
Fix for PHP 5.6

### DIFF
--- a/ee2/system/expressionengine/third_party/category_sorted_entries/pi.category_sorted_entries.php
+++ b/ee2/system/expressionengine/third_party/category_sorted_entries/pi.category_sorted_entries.php
@@ -1281,7 +1281,7 @@ class Category_sorted_entries {
 	* @access public
 	* @return string output buffer
 	*/
-	function usage()
+	public static function usage()
 	{
 
 		ob_start(); 


### PR DESCRIPTION
usage() needed to be a public static function on php 5.6